### PR TITLE
ci: disable parallel jobs to fix ci

### DIFF
--- a/.github/workflows/ci_mongo.yml
+++ b/.github/workflows/ci_mongo.yml
@@ -10,6 +10,7 @@ jobs:
   mongo:
     runs-on: ubuntu-18.04
     strategy:
+      max-parallel: 1
       matrix:
         node-version: [10.x, 12.x, 14.x]
     services:

--- a/.github/workflows/ci_redis.yml
+++ b/.github/workflows/ci_redis.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
+        max-parallel: 1
         node-version: [10.x, 12.x, 14.x]
     services:
       redis:

--- a/.github/workflows/ci_redis.yml
+++ b/.github/workflows/ci_redis.yml
@@ -10,8 +10,8 @@ jobs:
   redis:
     runs-on: ubuntu-latest
     strategy:
+      max-parallel: 1
       matrix:
-        max-parallel: 1
         node-version: [10.x, 12.x, 14.x]
     services:
       redis:


### PR DESCRIPTION
I think mongo ci was failing because matrix is runned in parallel. This should fix the ci finally